### PR TITLE
ci(github): add permissions for provenance publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
   },
   "scripts": {
     "lint": "eslint --cache .",


### PR DESCRIPTION
- Add permissions block to npm publish workflow for provenance support
- Set "provenance": true in publishConfig in package.json